### PR TITLE
Update service worker cache strategy

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'qrscanner-v1';
+const CACHE_NAME = 'qrscanner-v2';
 const ASSETS = [
   './',
   './index.html',
@@ -21,9 +21,9 @@ self.addEventListener('activate', (e) => {
 
 self.addEventListener('fetch', (e) => {
   const url = new URL(e.request.url);
-  if (url.origin === location.origin) {
+  if (url.origin === location.origin && e.request.method === 'GET') {
     e.respondWith(
-      caches.match(e.request).then((res) => res || fetch(e.request))
+      fetch(e.request).catch(() => caches.match(e.request))
     );
   }
 });


### PR DESCRIPTION
## Summary
- bump the service worker cache name to `qrscanner-v2` so older caches are discarded
- switch the fetch handler to a network-first strategy to ensure updated HTML is retrieved while keeping an offline fallback

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d6f3135728832f952929f24926f371