### PR TITLE
Fix H5T2 SkipCode tail encoding

### DIFF
--- a/skipcode32.js
+++ b/skipcode32.js
@@ -34,13 +34,15 @@ function toSym7(mask) {
   return out;
 }
 
+function tailLength(sym7) {
+  if (sym7[6] !== '0') return 2;
+  return sym7[5] !== '0' ? 1 : 0;
+}
+
 function tryH5T2Length(sym7) {
   let body = 0;
   for (let i = 0; i < 5; i++) if (sym7[i] !== '0') body++;
-  let tail = 0;
-  if (sym7[5] !== '0') tail++;
-  if (sym7[6] !== '0') tail++;
-  return 1 + body + tail;
+  return 1 + body + tailLength(sym7);
 }
 
 export function encode(mask) {
@@ -51,8 +53,9 @@ export function encode(mask) {
     for (let i = 0; i < 5; i++) if (sym7[i] !== '0') header |= (1 << (4 - i));
     let out = ALPHABET[header];
     for (let i = 0; i < 5; i++) if (sym7[i] !== '0') out += sym7[i];
-    if (sym7[5] !== '0') out += sym7[5];
-    if (sym7[6] !== '0') out += sym7[6];
+    const tail = tailLength(sym7);
+    if (tail >= 1) out += sym7[5];
+    if (tail >= 2) out += sym7[6];
     return out;
   }
   return sym7;

--- a/skipcode32.ts
+++ b/skipcode32.ts
@@ -34,13 +34,15 @@ function toSym7(mask: number): string {
   return out;
 }
 
+function tailLength(sym7: string): number {
+  if (sym7[6] !== '0') return 2;
+  return sym7[5] !== '0' ? 1 : 0;
+}
+
 function tryH5T2Length(sym7: string): number {
   let body = 0;
   for (let i = 0; i < 5; i++) if (sym7[i] !== '0') body++;
-  let tail = 0;
-  if (sym7[5] !== '0') tail++;
-  if (sym7[6] !== '0') tail++;
-  return 1 + body + tail;
+  return 1 + body + tailLength(sym7);
 }
 
 export function encode(mask: number): string {
@@ -51,8 +53,9 @@ export function encode(mask: number): string {
     for (let i = 0; i < 5; i++) if (sym7[i] !== '0') header |= (1 << (4 - i));
     let out = ALPHABET[header];
     for (let i = 0; i < 5; i++) if (sym7[i] !== '0') out += sym7[i];
-    if (sym7[5] !== '0') out += sym7[5];
-    if (sym7[6] !== '0') out += sym7[6];
+    const tail = tailLength(sym7);
+    if (tail >= 1) out += sym7[5];
+    if (tail >= 2) out += sym7[6];
     return out;
   }
   return sym7;


### PR DESCRIPTION
## Summary
- keep H5T2 tail symbols positional when the final tail symbol is non-zero
- update both `skipcode32.ts` and generated `skipcode32.js`

## Why
The scanner could emit a shortened code like `08` for a mask whose classic form is `0000008`. The sender decodes H5T2 tail symbols positionally, so that code is interpreted as the sixth symbol instead of the seventh. The encoder now emits `008` in that case, preserving the zero placeholder needed for round-trip decoding.

## Verification
- Checked representative masks including `0x00000001`, `0x00000002`, `0x00000003`, `0x00000401`, `0x10000001`, and `0xffffffff` against the sender-style H5T2 decoder.
