### PR TITLE
fix: keep scanner view constrained after completion overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,8 +20,50 @@
     button[disabled]{opacity:.5; cursor:not-allowed;}
     button:hover { background:#1f2937; }
     .muted { color:#9ca3af; font-size:12px; }
-    #readerShell { position:relative; width:75%; max-width:480px; margin:0; aspect-ratio:4/3; }
-    #reader { width:100%; height:100%; margin:0; box-sizing:border-box; }
+    #readerShell {
+      position:relative;
+      width:75%;
+      max-width:480px;
+      height:min(360px, 56.25vw);
+      margin:0;
+      overflow:hidden;
+      background:#0f172a;
+      border:1px solid #1f2937;
+      border-radius:12px;
+    }
+    #reader {
+      width:100%;
+      height:100%;
+      margin:0;
+      padding:0;
+      border:0;
+      border-radius:0;
+      box-sizing:border-box;
+      overflow:hidden;
+      background:#0f172a;
+    }
+    #reader > div,
+    #reader__scan_region {
+      width:100% !important;
+      height:100% !important;
+      min-height:0 !important;
+      border:0 !important;
+    }
+    #reader video {
+      width:100% !important;
+      height:100% !important;
+      object-fit:cover;
+    }
+    #reader img,
+    #reader canvas {
+      max-width:100% !important;
+      max-height:100% !important;
+    }
+    #reader__dashboard,
+    #reader__dashboard_section,
+    #reader__status_span {
+      display:none !important;
+    }
     #completeOverlay {
       position:absolute;
       inset:0;
@@ -122,7 +164,7 @@
     (async () => {
       if (window.matchMedia('(display-mode: standalone)').matches)
         document.getElementById('pwaStatus').textContent = 'PWA ✓';
-      if ('serviceWorker' in navigator) { try { await navigator.serviceWorker.register('./sw.js?v=9'); } catch {} }
+      if ('serviceWorker' in navigator) { try { await navigator.serviceWorker.register('./sw.js?v=10'); } catch {} }
     })();
 
     // 状態

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,7 @@
-const CACHE_NAME = 'qrscanner-v9';
+const CACHE_NAME = 'qrscanner-v10';
 const ASSETS = [
   './',
-  './index.html?v=9',
+  './index.html?v=10',
   './manifest.webmanifest?v=3',
   './fountain.js?v=2',
   './libs/fflate/esm/browser.js',


### PR DESCRIPTION
- Constrain the reader container height and overflow
- Keep html5-qrcode video inside the scanner frame
- Hide html5-qrcode dashboard elements that expand the layout
- Bump service worker cache for the layout fix